### PR TITLE
Fix Courses Query 

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web:npm run deploy:api
+web: npm run deploy:api

--- a/packages/unified-backend/index.js
+++ b/packages/unified-backend/index.js
@@ -139,7 +139,12 @@ const resolvers = {
  * Server instance. To do so, we'll import and use the ApolloServer constructor
  * function from the apollo-server library.
  */
-const server = new ApolloServer({ typeDefs, resolvers });
+const server = new ApolloServer({ 
+    typeDefs, 
+    resolvers,
+    introspection: true,
+    playground: true
+});
 
 /**
  * With the Apollo server instance now available to us, we can start 

--- a/packages/unified-backend/index.js
+++ b/packages/unified-backend/index.js
@@ -124,8 +124,8 @@ const ProgramModel = uoftDb.model('Subject', ProgramSchema, "Subjects");
  */
 const resolvers = {
     Query: {
-        courses: (_, { code = "all" }) => {
-            if (code == "all") { return CoursesModel.find(); }
+        courses: (_, { code }) => {
+            if (!code) { return CoursesModel.find(); }
             else { return CoursesModel.find({ code }); }
         },
         subjects: () => {


### PR DESCRIPTION
**Overview**
- The changes are live on the [playground](http://www.api.uoftcoursetools.tech/)
- To get all courses, the parameter is now: 
`courses(code: "")`
- Close #91 