### PR TITLE
Fixed code concatenating issue, reverted workaround

### DIFF
--- a/packages/app/src/components/CourseSearchBar.vue
+++ b/packages/app/src/components/CourseSearchBar.vue
@@ -30,12 +30,12 @@ export default {
       this.$apollo
         .query({
           query: gql`
-            query getCourse($courseCode: String!) {
-              courses(code: $courseCode) {
-                code
+            query getCourse($code: String!) {
+              courses(code: $code) {
+                courseCode: code
                 name
                 meeting_sections {
-                  code
+                  sectionCode: code
                   instructors
                   times {
                     day
@@ -48,7 +48,7 @@ export default {
             }
           `,
           variables: {
-            courseCode: this.selectedCourse.slice(
+            code: this.selectedCourse.slice(
               0,
               this.selectedCourse.indexOf(":")
             )

--- a/packages/app/src/components/CourseSectionPicker.vue
+++ b/packages/app/src/components/CourseSectionPicker.vue
@@ -37,11 +37,11 @@
               <v-list-item-group>
                 <v-list-item
                   v-for="meetingSection in meetingSections"
-                  :key="meetingSection.code"
+                  :key="meetingSection.sectionCode"
                   style="margin-bottom: 0px;"
                 >
                   <v-list-item-action>
-                    <v-radio :value="meetingSection.code.slice(-5)"></v-radio>
+                    <v-radio :value="meetingSection.sectionCode"></v-radio>
                   </v-list-item-action>
 
                   <v-list-item-content class="content-no-padding">
@@ -49,7 +49,7 @@
                       <v-col class="contain" cols="2">
                         <v-row class="center-vertical">
                           <v-col>
-                            <v-list-item-title>{{meetingSection.code.slice(-5)}}</v-list-item-title>
+                            <v-list-item-title>{{meetingSection.sectionCode}}</v-list-item-title>
                           </v-col>
                         </v-row>
                       </v-col>
@@ -60,7 +60,7 @@
                             <v-tooltip
                               top
                               v-if="checkConflict(time.day, 
-                                  time.start, time.end) != null && meetingSection.code.slice(-5) != timetableSelectedMeetingSections[activityType]"
+                                  time.start, time.end) != null && meetingSection.sectionCode != timetableSelectedMeetingSections[activityType]"
                             >
                               <template v-slot:activator="{ on }">
                                 <div
@@ -136,13 +136,13 @@ export default {
     activities() {
       return {
         lecture: this.course.meeting_sections.filter(
-          section => section.code.charAt(section.code.length - 5) === "L"
+          section => section.sectionCode.charAt(0) === "L"
         ),
         tutorial: this.course.meeting_sections.filter(
-          section => section.code.charAt(section.code.length - 5) === "T"
+          section => section.sectionCode.charAt(0) === "T"
         ),
         practical: this.course.meeting_sections.filter(
-          section => section.code.charAt(section.code.length - 5) === "P"
+          section => section.sectionCode.charAt(0) === "P"
         )
       };
     },
@@ -203,12 +203,12 @@ export default {
       for (let day in this.timetable) {
         const dayEvents = this.timetable[day];
         for (let event of dayEvents) {
-          if (event.code === this.course.code) {
+          if (event.code === this.course.courseCode) {
             if (event.sectionCode.charAt(0) == "L") {
-              selectedMeetingSections.lecture = event.sectionCode.slice(-5);
+              selectedMeetingSections.lecture = event.sectionCode;
             } else if (event.sectionCode.charAt(0) == "P") {
-              selectedMeetingSections.practical = event.sectionCode.slice(-5);
-            } else selectedMeetingSections.tutorial = event.sectionCode.slice(-5);
+              selectedMeetingSections.practical = event.sectionCode;
+            } else selectedMeetingSections.tutorial = event.sectionCode;
           }
         }
       }

--- a/packages/app/src/components/TimetableCourseCard.vue
+++ b/packages/app/src/components/TimetableCourseCard.vue
@@ -3,7 +3,7 @@
     <div class="course-info-card">
       <div class="course-card-header pb-4" :style="{ background: course.color }">
         <v-row class="pl-2 mb-2">
-          <v-col class=" ml-2" cols="10">{{ course.code }} {{ course.name }}</v-col>
+          <v-col class=" ml-2" cols="10">{{ course.courseCode }} {{ course.name }}</v-col>
           <v-spacer />
           <v-col cols="0.5" class="pr-0">
             <v-dialog v-model="dialog" scrollable width="810px" @input="atInput">
@@ -12,11 +12,11 @@
                   <v-icon>mdi-pencil-box-outline</v-icon>
                 </v-btn>
               </template>
-              <course-section-picker v-on:done="dialog = false" :code="course.code" ref="popUp"/>
+              <course-section-picker v-on:done="dialog = false" :code="course.courseCode" ref="popUp"/>
             </v-dialog>
           </v-col>
           <v-col cols="0.5" class=" pl-0">
-            <v-btn color="white" @click="deleteCourse({code: course.code})" icon>
+            <v-btn color="white" @click="deleteCourse({code: course.courseCode})" icon>
               <v-icon>mdi-delete</v-icon>
             </v-btn>
           </v-col>
@@ -73,10 +73,10 @@ export default {
       for (let day in this.timetable) {
         const dayEvents = this.timetable[day];
         for (let event of dayEvents) {
-          if (event.code == this.course.code) {
+          if (event.code == this.course.courseCode) {
             const instructor = event.instructors.length === 0 ? "TBA" : event.instructors[0]
             sections.push({
-              sectionCode: event.sectionCode.slice(-5),
+              sectionCode: event.sectionCode,
               day: day,
               start: event.start,
               end: event.end,

--- a/packages/app/src/components/TimetableEvent.vue
+++ b/packages/app/src/components/TimetableEvent.vue
@@ -22,7 +22,7 @@
               </v-btn>
             </div>
 
-            <div style="margin-left: 3px;">{{event.sectionCode.substring(event.sectionCode.length - 5)}}</div>
+            <div style="margin-left: 3px;">{{event.sectionCode}}</div>
 
             <div style="position: relative;">
               <div class="align-left">{{getFormattedTime(event.start, event.end)}}</div>

--- a/packages/app/src/store/index.js
+++ b/packages/app/src/store/index.js
@@ -39,7 +39,7 @@ export default new Vuex.Store({
       state.timetables = payload.timetables
     },
     addCourse(state, payload) {
-      state.selectedCourses[payload.course.code] = payload.course
+      state.selectedCourses[payload.course.courseCode] = payload.course
       state.takenColors.push(payload.course.color)
     },
     removeCourse(state, payload) {
@@ -90,6 +90,7 @@ export default new Vuex.Store({
       })
       const courses = Object.keys(context.state.selectedCourses).map(code => context.state.selectedCourses[code])
       const timetables = generateTimetables(courses)
+      console.log(timetables.length)
       context.commit("setTimetables", { timetables })
       context.commit("setTimetable", { timetable: context.state.timetables[0] })
     },

--- a/packages/app/src/timetable-planner/combinations/combinations.js
+++ b/packages/app/src/timetable-planner/combinations/combinations.js
@@ -1,16 +1,16 @@
 const courseMeetingSectionCombinations = (course) => {
-    const lectures = course.meeting_sections.filter(section => section.code.charAt(section.code.length - 5) === "L");
-    const tutorials = course.meeting_sections.filter(section => section.code.charAt(section.code.length - 5) === "T");
-    const practicals = course.meeting_sections.filter(section => section.code.charAt(section.code.length - 5) === "P");
+    const lectures = course.meeting_sections.filter(section => section.sectionCode.charAt(0) === "L");
+    const tutorials = course.meeting_sections.filter(section => section.sectionCode.charAt(0) === "T");
+    const practicals = course.meeting_sections.filter(section => section.sectionCode.charAt(0) === "P");
     console.log(lectures)
     for (const lecture of lectures) {
-        lecture.code = course.code + lecture.code;
+        lecture.comboCode = course.courseCode + lecture.sectionCode;
     }
     for (const tutorial of tutorials) {
-        tutorial.code = course.code + tutorial.code;
+        tutorial.comboCode = course.courseCode + tutorial.sectionCode;
     }
     for (const practical of practicals) {
-        practical.code = course.code + practical.code;
+        practical.comboCode = course.courseCode + practical.sectionCode;
     }
     const lecTutCombinations = [];
     for (const lecture of lectures) {
@@ -30,7 +30,7 @@ const courseMeetingSectionCombinations = (course) => {
             totalCombinations = lecTutCombinations;
         }
     }
-    return { code: course.code, combinations: totalCombinations };
+    return { code: course.courseCode, combinations: totalCombinations };
 };
 const courseCombinations = (courseMeetingSectionCombos) => {
     const outputs = [];

--- a/packages/app/src/timetable-planner/index.js
+++ b/packages/app/src/timetable-planner/index.js
@@ -54,8 +54,8 @@ const createTimetable = (meetingSectionCombo) => {
     for (const meetingSection of meetingSectionCombo) {
         for (const time of meetingSection.times) {
             const timetableSection = {
-                code: meetingSection.code.substring(0, 9),
-                sectionCode: meetingSection.code.substring(9),
+                code: meetingSection.comboCode.substring(0, meetingSection.comboCode.length - 5),
+                sectionCode: meetingSection.sectionCode,
                 instructors: meetingSection.instructors,
                 ...time,
             };
@@ -94,6 +94,7 @@ const generateTimetables = (courses) => {
             timetables.push(timetable);
         }
     }
+    console.log(timetables)
     return timetables;
 };
 export { generateTimetables, createTimetable, overlapExists };

--- a/packages/app/src/timetable-planner/types.d.ts
+++ b/packages/app/src/timetable-planner/types.d.ts
@@ -2,7 +2,7 @@ declare interface SymbolConstructor {
     readonly observable: symbol;
 }
 interface MeetingSection {
-    code: string;
+    sectionCode: string;
     instructors: string[];
     times: MeetingSectionTime[];
 }
@@ -31,7 +31,7 @@ interface Timetable {
     FRIDAY: TimetableSection[];
 }
 interface Course {
-    code: string;
+    courseCode: string;
     meeting_sections: MeetingSection[];
 }
 interface CourseMeetingSectionCombinations {


### PR DESCRIPTION
The graphql query has is now returning the right section codes without concatenating the course code with the section code, all previous workarounds to hide this issue has been reverted.