### PR TITLE
Fixed Warning Issue on Optimization Settings Component

### DIFF
--- a/packages/app/src/components/OptimizationSettings.vue
+++ b/packages/app/src/components/OptimizationSettings.vue
@@ -20,7 +20,7 @@
                         <v-btn-toggle v-model="selectedIdleOption">
                             <v-btn
                                 v-for="option in idleOptions"
-                                :key="option"
+                                :key="option.text"
                                 :color="option.color"
                                 outlined
                                 small


### PR DESCRIPTION
# Overview

The issue was caused by assigning the key of v-for to an object, rather than a primitive type.